### PR TITLE
fix(compose): make image tag configurable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     restart: unless-stopped
 
   synctv:
-    image: synctvorg/synctv:latest
+    image: synctvorg/synctv:${SYNCTV_IMAGE_TAG:-latest}
     container_name: synctv-app
     env_file:
       - path: .env.synctv


### PR DESCRIPTION
Use the release contract fallback `${SYNCTV_IMAGE_TAG:-latest}` for the SyncTV Compose image so suite preflight can validate and users can select a release image without editing the file.