### PR TITLE
fix(account): skip standalone room outbox events

### DIFF
--- a/synctv-api-common/src/impls/client/user.rs
+++ b/synctv-api-common/src/impls/client/user.rs
@@ -306,7 +306,10 @@ fn prepare_deleted_room_outbox_fanout(
         let prepared = api
             .room_lifecycle_fanout
             .prepare_room_deleted_outbox_fanout(room_id, deleted_by)?;
-        outbox_events.insert(*room_id, prepared.cloned_outbox_event());
+        let outbox_event = prepared.cloned_outbox_event();
+        if outbox_event.enqueue_outbox {
+            outbox_events.insert(*room_id, outbox_event);
+        }
         fanout.push(DeletedRoomAfterCommitFanout {
             room_id: *room_id,
             event: prepared.into_event(),


### PR DESCRIPTION
## Summary
- persist deleted-room events only when the prepared event requires the realtime outbox
- keep local post-commit fanout for standalone deployments
- prevent account closure from failing when cluster mode is disabled

## Verification
- cargo fmt --all -- --check
- cargo check -p synctv-api-common -p synctv-api-grpc -p synctv-api-http
- cargo test -p synctv-core deleted_room_outbox_config --lib