### PR TITLE
release: prepare v1.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7514,7 +7514,7 @@ dependencies = [
 
 [[package]]
 name = "synctv"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7580,7 +7580,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-adapter"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "axum",
  "http",
@@ -7596,7 +7596,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-api"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -7632,7 +7632,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-api-common"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "aes-gcm 0.11.0",
  "ammonia",
@@ -7711,7 +7711,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-api-grpc"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "aes-gcm 0.11.0",
  "ammonia",
@@ -7791,7 +7791,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-api-http"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "aes-gcm 0.11.0",
  "ammonia",
@@ -7873,7 +7873,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-cluster"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7910,7 +7910,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-common"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -7929,7 +7929,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-core"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "aes-gcm 0.11.0",
  "ammonia",
@@ -8009,7 +8009,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-core-testing"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8035,7 +8035,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-livestream"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8082,7 +8082,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-management"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "futures",
@@ -8115,7 +8115,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-media-providers"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "aes 0.9.2",
  "aes-gcm 0.11.0",
@@ -8178,7 +8178,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-proto"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "prost-protovalidate",
  "prost-reflect",
@@ -8191,7 +8191,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-proto-build"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "pbjson-build",
  "prost",
@@ -8202,7 +8202,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-proto-main"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "base64 0.23.0",
  "pbjson",
@@ -8221,7 +8221,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-proto-playback-provider"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "base64 0.23.0",
  "pbjson",
@@ -8242,7 +8242,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-proto-providers"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "base64 0.23.0",
  "pbjson",
@@ -8262,7 +8262,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-proxy"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8299,7 +8299,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-realtime"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8332,7 +8332,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-xiu"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 authors = ["SyncTV Contributors"]
 license = "MIT"

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "synctv-docs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "synctv-docs",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@astrojs/starlight": "0.41.7",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synctv-docs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/docs/src/lib/project.ts
+++ b/docs/src/lib/project.ts
@@ -1,5 +1,5 @@
 const defaultRepository = 'synctv-org/synctv';
-const defaultAppVersion = '1.0.1';
+const defaultAppVersion = '1.0.2';
 
 function readEnv(name: string): string | undefined {
   const value = process.env[name]?.trim();

--- a/helm/synctv/Chart.yaml
+++ b/helm/synctv/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: synctv
 description: A distributed video synchronization platform with real-time streaming (RTMP/HLS/WebRTC)
 type: application
-version: 1.0.1
-appVersion: "1.0.1"
+version: 1.0.2
+appVersion: "1.0.2"
 
 keywords:
   - synctv

--- a/helm/synctv/README.md
+++ b/helm/synctv/README.md
@@ -45,7 +45,7 @@ Install the released OCI chart:
 
 ```bash
 helm install synctv oci://ghcr.io/synctv-org/synctv/charts/synctv \
-  --version 1.0.1 \
+  --version 1.0.2 \
   --namespace synctv \
   --create-namespace
 ```


### PR DESCRIPTION
## Summary

- bump the Cargo workspace to 1.0.2
- synchronize Helm chart and documentation versions

## Verification

- `make fmt-check`
- `make clippy-check`
- `make nextest-default` (5,186 passed)
- `make nextest-ignored` (1,585 passed)
- `make validate-helm`