### PR TITLE
chore(docker): keep database and cache internal

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,8 +6,6 @@ services:
       POSTGRES_USER: synctv
       POSTGRES_PASSWORD: synctv
       POSTGRES_DB: synctv
-    ports:
-      - "127.0.0.1:5432:5432"
     volumes:
       - postgres_dev_data:/var/lib/postgresql
     healthcheck:
@@ -23,8 +21,6 @@ services:
   redis:
     image: redis:8
     container_name: synctv-redis-dev
-    ports:
-      - "127.0.0.1:6379:6379"
     volumes:
       - redis_dev_data:/data
     command: redis-server --appendonly yes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,6 @@ services:
     env_file:
       - path: .env.postgres
         required: true
-    ports:
-      # Keep database access local to the host; the app uses the internal Docker network.
-      - "127.0.0.1:5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql
     healthcheck:
@@ -26,9 +23,6 @@ services:
     env_file:
       - path: .env.redis
         required: true
-    ports:
-      # Keep cache access local to the host; the app uses the internal Docker network.
-      - "127.0.0.1:6379:6379"
     volumes:
       - redis_data:/data
     command: sh -ec 'exec redis-server --appendonly yes --requirepass "$$REDIS_PASSWORD"'


### PR DESCRIPTION
## Changes
- Remove PostgreSQL and Redis host port publications from production and development Compose files.
- Keep application connectivity through the existing Compose networks and service names.

## Validation
- docker compose -f docker-compose.dev.yml config --quiet
- git diff --check