### PR TITLE
fix(auth): warn on weak JWT secrets

### DIFF
--- a/synctv-core/src/service/auth/jwt.rs
+++ b/synctv-core/src/service/auth/jwt.rs
@@ -276,12 +276,11 @@ impl JwtService {
     fn validate_secret_entropy(secret: &str) -> Result<()> {
         // Requirement 1: Minimum length (32 characters = 256 bits minimum)
         const MIN_SECRET_LENGTH: usize = 32;
-        if secret.len() < MIN_SECRET_LENGTH {
+        let secret_char_count = secret.chars().count();
+        if secret_char_count < MIN_SECRET_LENGTH {
             return Err(Error::Internal(format!(
-                "JWT secret is too short ({} characters, need at least {}). \
-                 Use a secret with at least 32 characters for HMAC-SHA256.",
-                secret.len(),
-                MIN_SECRET_LENGTH
+                "JWT secret is too short ({secret_char_count} characters, need at least \
+                 {MIN_SECRET_LENGTH}). Use a secret with at least 32 characters for HMAC-SHA256."
             )));
         }
 
@@ -321,74 +320,54 @@ impl JwtService {
         // Requirement 3: Unique character ratio
         // Prevents "aaaa..." or "abcabcabc..." patterns
         let unique_chars: std::collections::HashSet<char> = secret.chars().collect();
-        let unique_ratio = usize_to_f64(unique_chars.len())? / usize_to_f64(secret.len())?;
+        let unique_ratio = usize_to_f64(unique_chars.len())? / usize_to_f64(secret_char_count)?;
 
-        // Require at least 25% unique characters
+        // Warn when fewer than 25% of the characters are unique.
         if unique_ratio < 0.25 {
-            return Err(Error::Internal(format!(
+            tracing::warn!(
                 "JWT secret has low character diversity ({:.0}% unique characters). \
                  Use a secret with more varied characters.",
                 unique_ratio * 100.0
-            )));
+            );
         }
 
-        // Requirement 4: Reject obvious patterns
-
-        // Check for all same character
-        if unique_chars.len() == 1 {
-            return Err(Error::Internal(
-                "JWT secret consists of a single repeated character. \
-                 Use a secret with varied characters."
-                    .to_string(),
-            ));
-        }
-
-        // Check for numeric-only secrets (even if long)
-        if secret.chars().all(|c| c.is_ascii_digit()) {
-            return Err(Error::Internal(
-                "JWT secret contains only digits. \
-                 Use a secret with mixed character types for better security."
-                    .to_string(),
-            ));
-        }
+        // Requirement 4: Warn about obvious patterns
 
         // Check for simple sequential patterns
         if Self::is_sequential_pattern(secret) {
-            return Err(Error::Internal(
+            tracing::warn!(
                 "JWT secret appears to be a simple sequential pattern. \
                  Use a randomly generated secret."
-                    .to_string(),
-            ));
+            );
         }
 
         // Check for repeated short patterns (e.g., "abcabcabc...")
         if Self::has_repeating_pattern(secret) {
-            return Err(Error::Internal(
+            tracing::warn!(
                 "JWT secret contains repeating patterns. \
                  Use a randomly generated secret without patterns."
-                    .to_string(),
-            ));
+            );
         }
 
         // Requirement 5: Shannon entropy calculation
         // More accurate than simple charset-based estimation
         let entropy = Self::calculate_shannon_entropy(secret)?;
         if entropy < MIN_SHANNON_ENTROPY {
-            return Err(Error::Internal(format!(
+            tracing::warn!(
                 "JWT secret has low entropy ({entropy:.1} bits/char, need at least {MIN_SHANNON_ENTROPY:.1}). \
                  Use a more random secret with varied characters."
-            )));
+            );
         }
 
         // Requirement 6: Estimate total entropy bits
         // Entropy = length * entropy_per_char
-        let estimated_entropy_bits = usize_to_f64(secret.len())? * entropy;
+        let estimated_entropy_bits = usize_to_f64(secret_char_count)? * entropy;
 
         if estimated_entropy_bits < MIN_JWT_SECRET_ENTROPY_BITS_F64 {
-            return Err(Error::Internal(format!(
+            tracing::warn!(
                 "JWT secret has insufficient total entropy ({estimated_entropy_bits:.0} bits, need at least {MIN_JWT_SECRET_ENTROPY_BITS} bits). \
                  Use a longer secret or one with more character variety."
-            )));
+            );
         }
 
         Ok(())
@@ -409,7 +388,7 @@ impl JwtService {
             *freq.entry(c).or_insert(0) += 1;
         }
 
-        let len = usize_to_f64(s.len())?;
+        let len = usize_to_f64(s.chars().count())?;
         let mut entropy = 0.0;
 
         for &count in freq.values() {
@@ -452,14 +431,15 @@ impl JwtService {
 
     /// Check if the string has a repeating pattern
     fn has_repeating_pattern(s: &str) -> bool {
-        if s.len() < 12 {
+        let chars: Vec<char> = s.chars().collect();
+        if chars.len() < 12 {
             return false;
         }
 
         // Check for patterns of length 2-8 that repeat
-        for pattern_len in 2..=8.min(s.len() / 3) {
-            let pattern = &s[..pattern_len];
-            let rest = &s[pattern_len..];
+        for pattern_len in 2..=8.min(chars.len() / 3) {
+            let pattern = &chars[..pattern_len];
+            let rest = &chars[pattern_len..];
 
             // Check if rest is mostly repetitions of pattern
             let repetitions = rest.len() / pattern_len;

--- a/synctv-core/src/service/auth/jwt/tests.rs
+++ b/synctv-core/src/service/auth/jwt/tests.rs
@@ -821,30 +821,32 @@ fn test_weak_secret_all_same_character_rejected() {
 }
 
 #[test]
-fn test_weak_secret_repeated_pattern_rejected() {
-    // Repeated pattern "abcabcabcabcabcabcabcabcabcabcab"
-    let result = JwtService::new("abcabcabcabcabcabcabcabcabcabcab");
+fn test_weak_secret_repeated_pattern_allowed_with_warning() {
+    let result = JwtService::new("abc1abc1abc1abc1abc1abc1abc1abc1");
     assert!(
-        result.is_err(),
-        "Repeated pattern secret should be rejected"
+        result.is_ok(),
+        "Repeated pattern secret should be allowed: {result:?}"
     );
 }
 
 #[test]
-fn test_weak_secret_keyboard_walk_rejected() {
+fn test_weak_secret_keyboard_walk_allowed_with_warning() {
     // Keyboard walk pattern with insufficient variety
     // "qwerty" repeated - this is a simple repeating pattern
     let result = JwtService::new("qwertyqwertyqwertyqwertyqwerty12");
-    assert!(result.is_err(), "Repeated keyboard walk should be rejected");
+    assert!(
+        result.is_ok(),
+        "Repeated keyboard walk should be allowed: {result:?}"
+    );
 }
 
 #[test]
-fn test_weak_secret_sequential_rejected() {
+fn test_weak_secret_sequential_allowed_with_warning() {
     // Sequential characters - fully sequential alphabet
     let result = JwtService::new("abcdefghijklmnopqrstuvwxyz123456");
     assert!(
-        result.is_err(),
-        "Sequential character secret should be rejected"
+        result.is_ok(),
+        "Sequential character secret should be allowed: {result:?}"
     );
 }
 
@@ -856,12 +858,11 @@ fn test_weak_secret_numeric_only_rejected() {
 }
 
 #[test]
-fn test_weak_secret_repeated_word_rejected() {
-    // Repeated low-variety word pattern with padding.
-    let result = JwtService::new("passpasspasspasspasspasspass12");
+fn test_weak_secret_repeated_word_allowed_with_warning() {
+    let result = JwtService::new("passpasspasspasspasspasspasspass12");
     assert!(
-        result.is_err(),
-        "Repeated low-variety secret should be rejected"
+        result.is_ok(),
+        "Repeated low-variety secret should be allowed: {result:?}"
     );
 }
 
@@ -898,13 +899,57 @@ fn test_strong_secret_with_spaces_accepted() {
 }
 
 #[test]
-fn test_weak_secret_low_unique_chars_rejected() {
-    // Low unique character count (mostly repeated chars)
-    let result = JwtService::new("aabbccddaabbccddaabbccddaabbccdd");
+fn test_weak_secret_low_unique_chars_allowed_with_warning() {
+    let result = JwtService::new("aabbccdd11aabbccdd11aabbccdd11aabbccdd11");
     assert!(
-        result.is_err(),
-        "Low unique character secret should be rejected"
+        result.is_ok(),
+        "Low unique character secret should be allowed: {result:?}"
     );
+}
+
+#[test]
+fn test_low_unique_character_ratio_is_non_blocking() {
+    let secret = concat!(
+        "aA0!bB1?cC2#",
+        "A0!bB1?cC2#a",
+        "0!bB1?cC2#aA",
+        "!bB1?cC2#aA0",
+        "bB1?cC2#aA0!",
+        "B1?cC2#aA0!b",
+        "1?cC2#aA0!bB",
+        "?cC2#aA0!bB1"
+    );
+
+    let result = JwtService::new(secret);
+
+    assert!(
+        result.is_ok(),
+        "Low unique character ratio should emit a warning without rejecting the secret: {result:?}"
+    );
+}
+
+#[test]
+fn test_non_ascii_secret_is_supported() {
+    let result = JwtService::new(concat!(
+        "\u{4e2d}a\u{6587}b\u{5bc6}c\u{94a5}d\u{6d4b}e\u{8bd5}f",
+        "\u{4e2d}a\u{6587}b\u{5bc6}c\u{94a5}d\u{6d4b}e\u{8bd5}f",
+        "\u{4e2d}a\u{6587}b\u{5bc6}c\u{94a5}d\u{6d4b}e\u{8bd5}f"
+    ));
+
+    assert!(
+        result.is_ok(),
+        "Non-ASCII secret should not panic or be rejected: {result:?}"
+    );
+}
+
+#[test]
+fn test_shannon_entropy_counts_characters_consistently() {
+    let entropy = ok(
+        JwtService::calculate_shannon_entropy("a\u{4e2d}"),
+        "entropy should be calculated",
+    );
+
+    assert!((entropy - 1.0).abs() < f64::EPSILON);
 }
 
 #[test]

--- a/synctv/src/app_config/mod.rs
+++ b/synctv/src/app_config/mod.rs
@@ -6,6 +6,12 @@ use serde::{Deserialize, Serialize};
 mod runtime;
 mod validation;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum StartupDiagnostic {
+    Info(String),
+    Warning(String),
+}
+
 const MIN_GRPC_MESSAGE_SIZE: usize = 1024 * 1024;
 const MAX_GRPC_MESSAGE_SIZE: usize = 1024 * 1024 * 1024;
 const DANGEROUS_CIDR_RANGES: &[&str] = &["0.0.0.0/0", "::/0", "0.0.0.0/0,::/0"];

--- a/synctv/src/app_config/validation.rs
+++ b/synctv/src/app_config/validation.rs
@@ -145,6 +145,74 @@ impl AppConfig {
         self.validate_core()
     }
 
+    /// Collect non-blocking configuration diagnostics for emission after logging is ready.
+    pub(crate) fn startup_diagnostics(&self) -> Vec<StartupDiagnostic> {
+        let mut diagnostics = Vec::new();
+
+        if self.jwt.secret == "change-me-in-production"
+            || self.jwt.secret.starts_with("CHANGE_ME_")
+            || is_known_dev_secret(&self.jwt.secret, KNOWN_DEV_JWT_SECRETS)
+        {
+            diagnostics.push(StartupDiagnostic::Warning(
+                "JWT secret appears to be a placeholder. Set SYNCTV_JWT_SECRET to a strong random value (openssl rand -base64 48)".to_string(),
+            ));
+        }
+
+        if self.redis.url.trim().is_empty()
+            && !self.redis_split_config_present()
+            && !self.cluster_runtime_enabled()
+        {
+            diagnostics.push(StartupDiagnostic::Info(
+                "Redis is not configured - running in standalone mode with in-memory fallbacks. All features work, but data (rate limits, brute-force counters, token blacklist) will not persist across restarts.".to_string(),
+            ));
+        }
+
+        if self.cluster_runtime_enabled() {
+            match self.livestream.hls_storage.backend() {
+                HlsStorageBackend::S3 => {}
+                HlsStorageBackend::SharedFile => {
+                    let path = self.livestream.hls_storage.path();
+                    let is_obviously_local = path.starts_with("/tmp/")
+                        || path == "/tmp"
+                        || path.starts_with("/var/tmp/")
+                        || path.starts_with("/dev/shm/");
+                    if is_obviously_local {
+                        diagnostics.push(StartupDiagnostic::Warning(format!(
+                            "livestream.hls_storage.type='shared_file' but hls_storage.path '{path}' appears to be a local-only path. Ensure this path is actually mounted from shared storage (NFS, CSI volume) on every replica. Otherwise remote HLS segment requests will read from a path that is not shared."
+                        )));
+                    }
+                }
+                HlsStorageBackend::File => diagnostics.push(StartupDiagnostic::Warning(
+                    "Cluster mode is enabled with livestream.hls_storage.type='file'. HLS remains functional through publisher-node proxying, but shared_file or S3 is recommended for production multi-replica HLS.".to_string(),
+                )),
+                HlsStorageBackend::Memory => diagnostics.push(StartupDiagnostic::Warning(
+                    "Cluster mode is enabled with livestream.hls_storage.type='memory'. HLS remains functional through publisher-node proxying, but memory storage is node-local and lost on restart. Use livestream.hls_storage.type='shared_file' or 's3' for production multi-replica HLS.".to_string(),
+                )),
+            }
+        } else if self.livestream.hls_storage.backend() == HlsStorageBackend::Memory {
+            diagnostics.push(StartupDiagnostic::Warning(
+                "The default HLS storage backend is MemoryStorage, which is node-local. HLS segments are lost on restart. For production multi-replica HLS, configure livestream.hls_storage.type='shared_file' with shared filesystem storage or livestream.hls_storage.type='s3' with S3-compatible object storage.".to_string(),
+            ));
+        }
+
+        if self.server.cors_allowed_origins.is_empty() {
+            diagnostics.push(StartupDiagnostic::Warning(
+                "server.cors_allowed_origins is empty. CORS requests will be rejected. Set allowed origins.".to_string(),
+            ));
+        }
+
+        if self.webrtc.enable_builtin_stun && self.webrtc.stun_external_addr.is_empty() {
+            let message = if self.cluster_runtime_enabled() {
+                "webrtc.enable_builtin_stun=true but stun_external_addr is not set in cluster mode. Startup will attempt STUN external address auto-detection from advertise_host, STUN_EXTERNAL_IP, or cloud metadata, and will skip the built-in STUN server if no public address is found. For deterministic production behavior, set webrtc.stun_external_addr to a client-reachable public ip:port or DNS name:port."
+            } else {
+                "webrtc.enable_builtin_stun=true but stun_external_addr is not set. Startup will try advertise_host, STUN_EXTERNAL_IP, and cloud metadata, and will skip the built-in STUN server if no public address is found. Set webrtc.stun_external_addr to the server's public ip:port or DNS name:port."
+            };
+            diagnostics.push(StartupDiagnostic::Warning(message.to_string()));
+        }
+
+        diagnostics
+    }
+
     fn validate_local_provider_http_config(
         path: &str,
         config: &LocalProviderHttpConfig,
@@ -589,16 +657,11 @@ impl AppConfig {
         // Validate JWT secret
         if self.jwt.secret.is_empty() {
             errors.push("JWT secret is empty".to_string());
-        } else if self.jwt.secret == "change-me-in-production"
-            || self.jwt.secret.starts_with("CHANGE_ME_")
-            || is_known_dev_secret(&self.jwt.secret, KNOWN_DEV_JWT_SECRETS)
-        {
-            errors.push("JWT secret appears to be a placeholder. Set SYNCTV_JWT_SECRET to a strong random value (openssl rand -base64 48)".to_string());
-        } else if self.jwt.secret.len() < 32 {
+        } else if self.jwt.secret.chars().count() < 32 {
             errors.push(format!(
                 "JWT secret is too short ({} chars). Minimum 32 characters required for security. \
                  Set SYNCTV_JWT_SECRET to a strong random value.",
-                self.jwt.secret.len()
+                self.jwt.secret.chars().count()
             ));
         }
 
@@ -764,14 +827,6 @@ impl AppConfig {
         }
         if self.redis.pipeline_buffer_size == 0 {
             errors.push("redis.pipeline_buffer_size must be greater than 0".to_string());
-        }
-
-        if !redis_url_present && !redis_split_present && !self.cluster_runtime_enabled() {
-            tracing::info!(
-                "Redis is not configured — running in standalone mode with in-memory fallbacks. \
-                 All features work, but data (rate limits, brute-force counters, token blacklist) \
-                 will not persist across restarts."
-            );
         }
 
         // Validate connection limits
@@ -1150,56 +1205,6 @@ impl AppConfig {
             );
         }
 
-        // HLS storage validation in cluster mode.
-        // Local backends are functional because non-publisher nodes can proxy HLS
-        // playlist/segment reads to the publisher node. Shared storage is still
-        // preferable for high-traffic production HLS because it avoids routing
-        // every remote segment request through the publisher node.
-        if cluster_mode_active {
-            match self.livestream.hls_storage.backend() {
-                HlsStorageBackend::S3 => {}
-                HlsStorageBackend::SharedFile => {
-                    let path = self.livestream.hls_storage.path();
-                    let is_obviously_local = path.starts_with("/tmp/")
-                        || path == "/tmp"
-                        || path.starts_with("/var/tmp/")
-                        || path.starts_with("/dev/shm/");
-                    if is_obviously_local {
-                        tracing::warn!(
-                            storage_path = %path,
-                            "livestream.hls_storage.type='shared_file' but hls_storage.path '{}' appears \
-                             to be a local-only path. Ensure this path is actually mounted from \
-                             shared storage (NFS, CSI volume) on every replica. Otherwise remote \
-                             HLS segment requests will read from a path that is not shared.",
-                            path
-                        );
-                    }
-                }
-                HlsStorageBackend::File => {
-                    tracing::warn!(
-                        "Cluster mode is enabled with livestream.hls_storage.type='file'. \
-                         HLS remains functional through publisher-node proxying, but shared_file or S3 is recommended for production multi-replica HLS."
-                    );
-                }
-                HlsStorageBackend::Memory => {
-                    tracing::warn!(
-                        "Cluster mode is enabled with livestream.hls_storage.type='memory'. \
-                         HLS remains functional through publisher-node proxying, but memory storage is node-local and lost on restart. \
-                         Use livestream.hls_storage.type='shared_file' or 's3' for production multi-replica HLS."
-                    );
-                }
-            }
-        } else if self.livestream.hls_storage.backend() == HlsStorageBackend::Memory {
-            // Single-node: warn about MemoryStorage only when the effective
-            // storage backend is actually the in-memory default.
-            tracing::warn!(
-                "The default HLS storage backend is MemoryStorage, which is node-local. \
-                 HLS segments are lost on restart. For production multi-replica HLS, \
-                 configure livestream.hls_storage.type='shared_file' with shared filesystem storage \
-                 or livestream.hls_storage.type='s3' with S3-compatible object storage."
-            );
-        }
-
         // Require cluster.secret when distributed mode is enabled.
         // An empty `cluster.secret` means that ANY node claiming to be part of the
         // cluster can call inter-node transport endpoints without authentication.
@@ -1261,38 +1266,6 @@ impl AppConfig {
                     "cluster.advertise_host must resolve to a routable address when distributed mode is enabled. \
                      Use the pod IP, node IP, or service-reachable hostname."
                         .to_string(),
-                );
-            }
-        }
-
-        // Warn if cors_allowed_origins is empty
-        if self.server.cors_allowed_origins.is_empty() {
-            tracing::warn!(
-                "server.cors_allowed_origins is empty. \
-                 CORS requests will be rejected. Set allowed origins."
-            );
-        }
-
-        // Validate STUN external address.
-        // In cluster/K8s/NAT environments, an explicit public stun_external_addr
-        // is preferred, but runtime bootstrap can also try advertise_host,
-        // STUN_EXTERNAL_IP, and cloud metadata. Configuration validation should
-        // therefore not fail-closed just because the explicit field is empty.
-        if self.webrtc.enable_builtin_stun && self.webrtc.stun_external_addr.is_empty() {
-            if self.cluster_runtime_enabled() {
-                tracing::warn!(
-                    "webrtc.enable_builtin_stun=true but stun_external_addr is not set in cluster mode. \
-                     Startup will attempt STUN external address auto-detection from advertise_host, \
-                     STUN_EXTERNAL_IP, or cloud metadata, and will skip the built-in STUN server \
-                     if no public address is found. For deterministic production behavior, set \
-                     webrtc.stun_external_addr to a client-reachable public ip:port or DNS name:port."
-                );
-            } else {
-                tracing::warn!(
-                    "webrtc.enable_builtin_stun=true but stun_external_addr is not set. \
-                     Startup will try advertise_host, STUN_EXTERNAL_IP, and cloud metadata, and \
-                     will skip the built-in STUN server if no public address is found. \
-                     Set webrtc.stun_external_addr to the server's public ip:port or DNS name:port."
                 );
             }
         }
@@ -1404,8 +1377,33 @@ mod tests {
     };
     use crate::app_config::{
         AppConfig, ClusterChannelConfig, ClusterDiscoveryMode, LogFileOutput, LogOutput,
-        SecurityConfig, SsrfConfig,
+        SecurityConfig, SsrfConfig, StartupDiagnostic,
     };
+
+    #[test]
+    fn placeholder_jwt_secret_is_reported_as_a_startup_warning() {
+        let mut config = AppConfig::default();
+        config.jwt.secret = "CHANGE_ME_this-placeholder-is-long-enough".to_string();
+
+        assert!(config.startup_diagnostics().iter().any(|diagnostic| {
+            matches!(
+                diagnostic,
+                StartupDiagnostic::Warning(message)
+                    if message.contains("JWT secret appears to be a placeholder")
+            )
+        }));
+    }
+
+    #[test]
+    fn short_jwt_secret_remains_a_validation_error() {
+        let mut config = AppConfig::default();
+        config.jwt.secret = "Short-secret-with-2-classes".to_string();
+
+        let errors = config.validate().expect_err("short JWT secrets must fail");
+        assert!(errors
+            .iter()
+            .any(|error| error.contains("JWT secret is too short")));
+    }
 
     #[test]
     fn project_url_accepts_http_urls_with_project_paths() {

--- a/synctv/src/cli/execute/config.rs
+++ b/synctv/src/cli/execute/config.rs
@@ -9,6 +9,16 @@ pub(super) fn execute_config(config_command: ConfigCommand) -> Result<()> {
             } else {
                 context.validated_config()?
             };
+            for diagnostic in config.startup_diagnostics() {
+                match diagnostic {
+                    crate::app_config::StartupDiagnostic::Info(message) => {
+                        eprintln!("Info: {message}");
+                    }
+                    crate::app_config::StartupDiagnostic::Warning(message) => {
+                        eprintln!("Warning: {message}");
+                    }
+                }
+            }
             println!("Configuration is valid");
             println!("API address: {}", config.api_address());
             Ok(())

--- a/synctv/src/cli/execute/db.rs
+++ b/synctv/src/cli/execute/db.rs
@@ -5,6 +5,7 @@ pub(super) async fn execute_db(db_command: DbCommand) -> Result<()> {
     let config = context.validated_config()?;
     let _log_guard =
         synctv_core::logging::init_logging(&crate::resource_options::logging_options(&config))?;
+    log_startup_diagnostics(&config);
 
     match db_command.command {
         DbSubcommand::Migrate(args) => {

--- a/synctv/src/cli/execute/mod.rs
+++ b/synctv/src/cli/execute/mod.rs
@@ -106,6 +106,15 @@ use stop::execute_stop;
 use system::execute_system;
 use user::execute_user;
 
+fn log_startup_diagnostics(config: &crate::app_config::AppConfig) {
+    for diagnostic in config.startup_diagnostics() {
+        match diagnostic {
+            crate::app_config::StartupDiagnostic::Info(message) => tracing::info!("{message}"),
+            crate::app_config::StartupDiagnostic::Warning(message) => tracing::warn!("{message}"),
+        }
+    }
+}
+
 #[cfg(test)]
 pub(in crate::cli) use db::{database_summary, DatabaseCliOutput};
 #[cfg(test)]

--- a/synctv/src/cli/execute/serve.rs
+++ b/synctv/src/cli/execute/serve.rs
@@ -8,6 +8,7 @@ pub(super) async fn execute_serve(args: ServeArgs) -> Result<()> {
 
     let _log_guard =
         synctv_core::logging::init_logging(&crate::resource_options::logging_options(&config))?;
+    log_startup_diagnostics(&config);
 
     if args.dry_run {
         tracing::info!("Configuration and logging initialized successfully");

--- a/synctv/src/config_loader.rs
+++ b/synctv/src/config_loader.rs
@@ -767,7 +767,7 @@ pub fn load_config_with_options(options: &LoadConfigOptions) -> Result<Config> {
             Ok(loaded) => {
                 if !loaded.unknown.is_empty() {
                     let message = loaded.unknown.strict_error_message();
-                    tracing::warn!("Ignoring unknown configuration setting(s): {message}");
+                    eprintln!("Warning: Ignoring unknown configuration setting(s): {message}");
                 }
                 if options.verbose {
                     tracing::info!(path = %display_path, "Config file loaded");
@@ -811,7 +811,7 @@ pub fn load_config_with_options(options: &LoadConfigOptions) -> Result<Config> {
             )?;
             if !loaded.unknown.is_empty() {
                 let message = loaded.unknown.strict_error_message();
-                tracing::warn!("Ignoring unknown configuration setting(s): {message}");
+                eprintln!("Warning: Ignoring unknown configuration setting(s): {message}");
             }
             loaded.config
         }
@@ -827,9 +827,6 @@ pub fn load_config_with_options(options: &LoadConfigOptions) -> Result<Config> {
     if options.validate {
         // Validate configuration (fail fast on misconfigurations)
         if let Err(errors) = config.validate() {
-            for error in &errors {
-                tracing::error!(%error, "Config validation error");
-            }
             return Err(anyhow::anyhow!(
                 "Configuration validation failed with {} error(s): {}",
                 errors.len(),


### PR DESCRIPTION
## Summary

- keep JWT minimum length and character-class requirements as blocking validation errors
- downgrade heuristic quality checks such as low diversity, repeated patterns, and low entropy to startup warnings
- emit configuration warnings after logging initialization, with stderr fallback for config validation and unknown settings
- count Unicode characters consistently in secret length, entropy, and pattern checks

## Tests

- `cargo test -p synctv-core service::auth::jwt::tests`
- `cargo test -p synctv app_config::validation::tests`
- `cargo test -p synctv config_loader::tests`
- `cargo check -p synctv`
- `cargo fmt --all -- --check`