### PR TITLE
release: prepare v1.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7527,7 +7527,7 @@ dependencies = [
 
 [[package]]
 name = "synctv"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7593,7 +7593,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-adapter"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "axum",
  "http",
@@ -7608,7 +7608,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-api"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -7644,7 +7644,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-api-common"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "aes-gcm 0.11.0",
  "ammonia",
@@ -7723,7 +7723,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-api-grpc"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "aes-gcm 0.11.0",
  "ammonia",
@@ -7803,7 +7803,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-api-http"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "aes-gcm 0.11.0",
  "ammonia",
@@ -7885,7 +7885,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-cluster"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7922,7 +7922,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-common"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -7940,7 +7940,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-core"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "aes-gcm 0.11.0",
  "ammonia",
@@ -8013,7 +8013,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-core-testing"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8039,7 +8039,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-livestream"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8086,7 +8086,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-management"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "futures",
@@ -8119,7 +8119,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-media-providers"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "aes 0.9.2",
  "aes-gcm 0.11.0",
@@ -8182,7 +8182,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-proto"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "prost-protovalidate",
  "prost-reflect",
@@ -8195,7 +8195,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-proto-build"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "pbjson-build",
  "prost",
@@ -8206,7 +8206,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-proto-main"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "base64 0.23.1",
  "pbjson",
@@ -8224,7 +8224,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-proto-playback-provider"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "base64 0.23.1",
  "pbjson",
@@ -8245,7 +8245,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-proto-providers"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "base64 0.23.1",
  "pbjson",
@@ -8264,7 +8264,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-proxy"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8298,7 +8298,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-realtime"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8327,7 +8327,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-xiu"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 authors = ["SyncTV Contributors"]
 license = "MIT"

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "synctv-docs",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "synctv-docs",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@astrojs/starlight": "0.41.7",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synctv-docs",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/docs/src/lib/project.ts
+++ b/docs/src/lib/project.ts
@@ -1,5 +1,5 @@
 const defaultRepository = 'synctv-org/synctv';
-const defaultAppVersion = '1.0.2';
+const defaultAppVersion = '1.0.3';
 
 function readEnv(name: string): string | undefined {
   const value = process.env[name]?.trim();

--- a/helm/synctv/Chart.yaml
+++ b/helm/synctv/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: synctv
 description: A distributed video synchronization platform with real-time streaming (RTMP/HLS/WebRTC)
 type: application
-version: 1.0.2
-appVersion: "1.0.2"
+version: 1.0.3
+appVersion: "1.0.3"
 
 keywords:
   - synctv

--- a/helm/synctv/README.md
+++ b/helm/synctv/README.md
@@ -45,7 +45,7 @@ Install the released OCI chart:
 
 ```bash
 helm install synctv oci://ghcr.io/synctv-org/synctv/charts/synctv \
-  --version 1.0.2 \
+  --version 1.0.3 \
   --namespace synctv \
   --create-namespace
 ```

--- a/scripts/set-release-version.sh
+++ b/scripts/set-release-version.sh
@@ -68,7 +68,7 @@ if [ "$cargo_version" != "$version" ] ||
   [ "$docs_lock_version" != "$version" ] ||
   [ "$docs_lock_root_version" != "$version" ] ||
   [ "$docs_default_app_version" != "$version" ] ||
-  [ "$compose_image" != "synctvorg/synctv:latest" ]; then
+  [ "$compose_image" != 'synctvorg/synctv:${SYNCTV_IMAGE_TAG:-latest}' ]; then
   echo "Failed to synchronize release version across Cargo.toml, Helm chart, Compose, and docs metadata." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- bump the server, Helm chart, and documentation metadata to v1.0.3
- keep the Compose image fallback validation aligned with the configurable image tag
- release the latest upstream main commit with personal user blocking

## Verification

- `make fmt-check`
- `make validate-helm`
- `cargo test -p synctv-api-common user_block --locked`