### PR TITLE
release: prepare v1.0.4

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -88,7 +88,7 @@ jobs:
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: stable
-          flutter-version: 3.44.8
+          flutter-version: 3.47.2
           cache: true
 
       - name: Cache Web build inputs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8189,7 +8189,7 @@ dependencies = [
 
 [[package]]
 name = "synctv"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8255,7 +8255,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-adapter"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "axum",
  "http",
@@ -8270,7 +8270,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-api"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "async-trait",
  "axum",
@@ -8306,7 +8306,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-api-common"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "aes-gcm 0.11.1",
  "ammonia",
@@ -8385,7 +8385,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-api-grpc"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "aes-gcm 0.11.1",
  "ammonia",
@@ -8465,7 +8465,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-api-http"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "aes-gcm 0.11.1",
  "ammonia",
@@ -8549,7 +8549,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-cluster"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8586,7 +8586,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-common"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -8604,7 +8604,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-core"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "aes-gcm 0.11.1",
  "ammonia",
@@ -8678,7 +8678,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-core-testing"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8704,7 +8704,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-livestream"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8751,7 +8751,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-management"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "futures",
@@ -8784,7 +8784,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-media-providers"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "aes 0.9.3",
  "aes-gcm 0.11.1",
@@ -8847,7 +8847,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-proto"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "prost-protovalidate",
  "prost-reflect",
@@ -8860,7 +8860,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-proto-build"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "pbjson-build",
  "prost",
@@ -8871,7 +8871,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-proto-main"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "base64 0.23.1",
  "pbjson",
@@ -8889,7 +8889,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-proto-playback-provider"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "base64 0.23.1",
  "pbjson",
@@ -8910,7 +8910,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-proto-providers"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "base64 0.23.1",
  "pbjson",
@@ -8929,7 +8929,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-proxy"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8963,7 +8963,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-realtime"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8992,7 +8992,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-web-ui"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "brotli",
  "flate2",
@@ -9005,7 +9005,7 @@ dependencies = [
 
 [[package]]
 name = "synctv-xiu"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 authors = ["SyncTV Contributors"]
 license = "MIT"

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "synctv-docs",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "synctv-docs",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@astrojs/starlight": "0.41.10",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synctv-docs",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/docs/src/lib/project.ts
+++ b/docs/src/lib/project.ts
@@ -1,5 +1,5 @@
 const defaultRepository = 'synctv-org/synctv';
-const defaultAppVersion = '1.0.3';
+const defaultAppVersion = '1.0.4';
 
 function readEnv(name: string): string | undefined {
   const value = process.env[name]?.trim();

--- a/helm/synctv/Chart.yaml
+++ b/helm/synctv/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: synctv
 description: A distributed video synchronization platform with real-time streaming (RTMP/HLS/WebRTC)
 type: application
-version: 1.0.3
-appVersion: "1.0.3"
+version: 1.0.4
+appVersion: "1.0.4"
 
 keywords:
   - synctv

--- a/helm/synctv/README.md
+++ b/helm/synctv/README.md
@@ -45,7 +45,7 @@ Install the released OCI chart:
 
 ```bash
 helm install synctv oci://ghcr.io/synctv-org/synctv/charts/synctv \
-  --version 1.0.3 \
+  --version 1.0.4 \
   --namespace synctv \
   --create-namespace
 ```

--- a/synctv-web-ui/web-ui.production.toml
+++ b/synctv-web-ui/web-ui.production.toml
@@ -3,8 +3,8 @@ schema-version = 1
 [source]
 kind = "git"
 repository = "https://github.com/synctv-org/synctv-app.git"
-revision = "64235a3584e4fa97560629e34f0160cc44672898"
-commit = "64235a3584e4fa97560629e34f0160cc44672898"
+revision = "24109a49b2e27f7772d067fae66b622431c942d5"
+commit = "24109a49b2e27f7772d067fae66b622431c942d5"
 
 [build]
 flutter = "flutter"


### PR DESCRIPTION
## Summary\n- bump server, Helm chart, and documentation metadata to 1.0.4\n- pin production Web UI to synctv-app commit 24109a49b2e27f7772d067fae66b622431c942d5\n- use Flutter 3.47.2 in the Docker Web UI build to satisfy the pinned client SDK\n- release the latest upstream main commit 940d566ff\n\n## Verification\n- make fmt-check\n- make validate-helm\n- make check\n- make web-ui-build (Flutter 3.47.2; generated version.json 1.1.24+23)\n- verify-web-ui-pin\n- cargo test -p synctv-api-common user_block --locked